### PR TITLE
Fix badges

### DIFF
--- a/fivekmrun_app_flutter/lib/common/date_extensions.dart
+++ b/fivekmrun_app_flutter/lib/common/date_extensions.dart
@@ -7,4 +7,13 @@ extension DateTimeExtensions on DateTime {
 
     return date;
   }
+
+  DateTime nextSunday() {
+    DateTime date = this;
+    while (date.weekday != 7) {
+      date = date.add(Duration(days: 1));
+    }
+
+    return date;
+  }
 }

--- a/fivekmrun_app_flutter/test/common/badges_test.dart
+++ b/fivekmrun_app_flutter/test/common/badges_test.dart
@@ -14,53 +14,27 @@ void main() {
     expect(hasSelfieBadge(runs), false);
   });
 
-  test('should have max badge this year', () {
+  test('should never have max badge this year', () {
     var runs = <Run>[];
 
     var now = DateTime.now();
-    var saturday = now.lastSaturday();
-    while (saturday.year == now.year) {
-      runs.add(new Run(date: saturday, isSelfie: false));
-      saturday = saturday.subtract(Duration(days: 7));
-    }
-
-    expect(hasMaxBadge(runs), true);
-  });
-
-  test('should not have max badge this year', () {
-    var runs = <Run>[];
-
-    var now = DateTime.now();
-    var saturday = now.lastSaturday().subtract(Duration(days: 7));
-    while (saturday.year == now.year) {
-      runs.add(new Run(date: saturday, isSelfie: false));
-      saturday = saturday.subtract(Duration(days: 7));
+    var date = now;
+    while (date.year == now.year) {
+      runs.add(new Run(date: date, isSelfie: false));
+      date = date.subtract(Duration(days: 1));
     }
 
     expect(hasMaxBadge(runs), false);
   });
 
-  test('should have selfie badge this year', () {
+  test('should never have selfie badge this year', () {
     var runs = <Run>[];
 
     var now = DateTime.now();
-    var saturday = now.lastSaturday();
-    while (saturday.year == now.year) {
-      runs.add(new Run(date: saturday, isSelfie: true));
-      saturday = saturday.subtract(Duration(days: 7));
-    }
-
-    expect(hasSelfieBadge(runs), true);
-  });
-
-  test('should not have selfie badge this year', () {
-    var runs = <Run>[];
-
-    var now = DateTime.now();
-    var saturday = now.lastSaturday().subtract(Duration(days: 7));
-    while (saturday.year == now.year) {
-      runs.add(new Run(date: saturday, isSelfie: true));
-      saturday = saturday.subtract(Duration(days: 7));
+    var date = now;
+    while (date.year == now.year) {
+      runs.add(new Run(date: date, isSelfie: true));
+      date = date.subtract(Duration(days: 1));
     }
 
     expect(hasMaxBadge(runs), false);
@@ -75,7 +49,6 @@ void main() {
       runs.add(new Run(date: saturday, isSelfie: false));
       saturday = saturday.subtract(Duration(days: 7));
     }
-
     expect(hasMaxBadge(runs), true);
   });
 


### PR DESCRIPTION
Fix Max and Selfie Max logic

## MAX Badge
Max badge is given if the user has official run for each Saturday of the year.

Max badge is **never** given for the current years.

## MAX Selfie
Max selfie badge is given if the user has a selfie run at the end of each week(Sunday) in the year. 

Incomplete weeks at the start of the year  **are required to receive the badge**. For example if 1st of January is Sunday, you will still need to have a selfie for this week in order to take the badge (it may be a run form 31st Dec from the previous year though).

Incomplete weeks at the end of the year **are NOT required to receive the badge**. For example, if the last week of the year starts on 29 Dec - you don't have to have a selfie run for this week to get the badge.


Max selfie badge is **never** given for the current years.